### PR TITLE
feat(aws)/create-opinionated-kestra-cloudformation

### DIFF
--- a/cloudformation/minimal-infra.yaml
+++ b/cloudformation/minimal-infra.yaml
@@ -1,0 +1,301 @@
+# aws cloudformation create-stack \                                                                     ()
+#   --region eu-west-1 \
+#   --stack-name kestra-marketplace-stack \
+#   --template-body file://./minimal-infra.yaml \
+#   --parameters \
+#     ParameterKey=MasterUserPassword,ParameterValue=MySecurePass123 \
+#     ParameterKey=BasicAuthUser,ParameterValue=admin@kestra.io \
+#     ParameterKey=BasicAuthPassword,ParameterValue=SuperSecret123 \
+#     ParameterKey=BucketName,ParameterValue=kestra-storage-marketplace-stack-241025 \
+#     ParameterKey=AWSRegion,ParameterValue=eu-west-1 \
+#     ParameterKey=VpcId,ParameterValue=vpc-08c780d509bd679ff \
+#     ParameterKey=SubnetIdEC2,ParameterValue=subnet-0c8d554dba1bab639 \
+#     ParameterKey=SubnetIdRDS1,ParameterValue=subnet-0ec14699238d167c3 \
+#     ParameterKey=SubnetIdRDS2,ParameterValue=subnet-099b219b9c3440fb4 \
+#     ParameterKey=DBInstanceIdentifier,ParameterValue=kestra-db \
+#     ParameterKey=DBName,ParameterValue=kestra \
+#     ParameterKey=DBEngineVersion,ParameterValue=17.4 \
+#     ParameterKey=DBInstanceClass,ParameterValue=db.t4g.micro \
+#     ParameterKey=InternalCIDR,ParameterValue=172.31.0.0/16 \
+#     ParameterKey=EC2InstanceType,ParameterValue=t3.medium \
+#   --capabilities CAPABILITY_IAM
+#
+# aws cloudformation delete-stack \                                                                     ()
+#   --region eu-west-1 \
+#   --stack-name kestra-marketplace-stack
+# -----------------------------------------------------------------------------
+# Prerequisites (manual setup required before running the stack)
+# - An existing VPC
+# - Existing subnets inside that VPC
+# - Appropriate IAM permissions for the user running the command
+# -----------------------------------------------------------------------------
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: PostgreSQL RDS, S3 bucket, and EC2 (with Docker) in eu-west-1
+
+Parameters:
+  MasterUsername:
+    Type: String
+    Default: kestra
+  MasterUserPassword:
+    Type: String
+    NoEcho: true
+  BucketName:
+    Type: String
+  LatestAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+  AWSRegion:
+    Type: String
+    Default: eu-west-1
+    Description: The AWS region for S3 and general configuration
+  BasicAuthUser:
+    Type: String
+    Default: admin@kestra.io
+    Description: Kestra UI basic auth username
+  BasicAuthPassword:
+    Type: String
+    NoEcho: true
+    Description: Kestra UI basic auth password
+  DBInstanceIdentifier:
+    Type: String
+    Default: kestra
+  DBName:
+    Type: String
+    Default: kestra
+  DBEngineVersion:
+    Type: String
+    Default: "17.4"
+  DBInstanceClass:
+    Type: String
+    Default: db.t4g.micro
+  VpcId:
+    Type: String
+  SubnetIdEC2:
+    Type: String
+  SubnetIdRDS1:
+    Type: String
+  SubnetIdRDS2:
+    Type: String
+  InternalCIDR:
+    Type: String
+  EC2InstanceType:
+    Type: String
+    Default: t3.medium
+
+Resources:
+  # -------------------------
+  # PostgreSQL RDS Instance
+  # -------------------------
+  PostgresDB:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier:
+        Ref: DBInstanceIdentifier
+      DBName:
+        Ref: DBName
+      Engine: postgres
+      EngineVersion:
+        Ref: DBEngineVersion
+      MasterUsername:
+        Ref: MasterUsername
+      MasterUserPassword:
+        Ref: MasterUserPassword
+      AllocatedStorage: 20
+      DBInstanceClass:
+        Ref: DBInstanceClass
+      PubliclyAccessible: false
+      BackupRetentionPeriod: 0
+      MultiAZ: false
+      StorageType: gp2
+      DeletionProtection: false
+      DeleteAutomatedBackups: true
+      AutoMinorVersionUpgrade: false
+      VPCSecurityGroups:
+        - Ref: RDSSecurityGroup
+      DBSubnetGroupName:
+        Ref: DBSubnetGroup
+
+  # -------------------------
+  # DB Subnet Group for RDS
+  # -------------------------
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Use existing VPC subnets for RDS
+      SubnetIds:
+        - Ref: SubnetIdRDS1
+        - Ref: SubnetIdRDS2
+      Tags:
+        - Key: Name
+          Value: kestra-db-subnet-group
+
+  # -------------------------
+  # Security Group for RDS
+  # -------------------------
+  RDSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow EC2 to access RDS on port 5432
+      VpcId:
+        Ref: VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId:
+            Ref: AppSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+
+  # -------------------------
+  # S3 Bucket
+  # -------------------------
+  StorageBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      BucketName:
+        Ref: BucketName
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  # -------------------------
+  # EC2 Security Group
+  # -------------------------
+  AppSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow Kestra UI, and RDS access within VPC
+      VpcId:
+        Ref: VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          CidrIp:
+            Ref: InternalCIDR
+          Description: RDS internal access
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          CidrIp: 0.0.0.0/0
+          Description: Kestra port UI
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+
+  # -------------------------
+  # EC2 Instance
+  # -------------------------
+  AppEC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      SubnetId:
+        Ref: SubnetIdEC2
+      IamInstanceProfile:
+        Ref: EC2InstanceProfile
+      InstanceType:
+        Ref: EC2InstanceType
+      SecurityGroupIds:
+        - Ref: AppSecurityGroup
+      ImageId:
+        Ref: LatestAmiId
+      Tags:
+        - Key: Redeploy
+          Value: "true"
+      UserData:
+        Fn::Base64:
+          Fn::Sub: |
+            #!/bin/bash
+            set -e
+            dnf update -y
+            dnf install -y docker
+            systemctl enable docker
+            systemctl start docker
+            usermod -aG docker ec2-user
+
+            cat <<EOF > /home/ec2-user/application-aws-ec2-marketplace.yaml
+            datasources:
+              postgres:
+                url: jdbc:postgresql://${PostgresDB.Endpoint.Address}:5432/${DBName}
+                driverClassName: org.postgresql.Driver
+                username: ${MasterUsername}
+                password: ${MasterUserPassword}
+            kestra:
+              server:
+                basic-auth:
+                  enabled: true
+                  username: ${BasicAuthUser}
+                  password: ${BasicAuthPassword}
+              repository:
+                type: postgres
+              storage:
+                type: s3
+                s3:
+                  region: ${AWSRegion}
+                  bucket: ${StorageBucket}
+              queue:
+                type: postgres
+              tasks:
+                tmp-dir:
+                  path: "/tmp/kestra-wd/tmp"
+              url: "http://localhost:8080/"
+            EOF
+
+            docker run --pull=always --rm -d \
+              -p 8080:8080 \
+              --user=root \
+              -e MICRONAUT_ENVIRONMENTS=aws-ec2-marketplace \
+              -v /home/ec2-user/application-aws-ec2-marketplace.yaml:/etc/config/application-aws-ec2-marketplace.yaml \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              --name kestra \
+              kestra/kestra:latest server standalone --config /etc/config/application-aws-ec2-marketplace.yaml
+
+            echo "Config file written to /home/ec2-user/application-aws-ec2-marketplace.yaml" > /home/ec2-user/READY.txt
+
+  # -------------------------
+  # IAM Role and Instance Profile
+  # -------------------------
+  EC2S3AccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: EC2S3AccessPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:DeleteObject
+                  - s3:ListBucket
+                Resource:
+                  - Fn::GetAtt:
+                      - StorageBucket
+                      - Arn
+                  - Fn::Sub: "${StorageBucket.Arn}/*"
+
+  EC2InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"
+      Roles:
+        - Ref: EC2S3AccessRole
+


### PR DESCRIPTION
This pull request introduces a new CloudFormation template, `minimal-infra.yaml`, which provisions a minimal AWS infrastructure stack for the Kestra Marketplace. The template automates the setup of a PostgreSQL RDS instance, S3 bucket, EC2 instance (with Docker and Kestra server), and all required networking and IAM resources. It also includes usage instructions and prerequisites for deploying and removing the stack.

Infrastructure provisioning:

* Adds a CloudFormation template (`minimal-infra.yaml`) that provisions a PostgreSQL RDS instance, S3 storage bucket, and an EC2 instance running Docker and the Kestra server, with all necessary parameters for customization.
* Configures VPC, subnets, and security groups to ensure secure connectivity between EC2 and RDS, and exposes the Kestra UI on port 8080.

Automation and configuration:

* Includes EC2 user data to automate installation of Docker, configuration of Kestra, and launching of the Kestra server container with environment-specific settings.
* Sets up IAM roles and instance profiles to allow the EC2 instance secure access to the S3 bucket for storage operations.

Documentation and usage guidance:

* Provides detailed stack creation and deletion commands, plus prerequisites for successful deployment, directly in the template file comments.